### PR TITLE
fix: pass a noop as a callback to bound functions

### DIFF
--- a/index.js
+++ b/index.js
@@ -326,7 +326,7 @@ class NatAPI {
 
       if (self.autoUpdate) {
         self._upnpIntervals[opts.publicPort + ':' + opts.privatePort + '-' + opts.protocol] = setInterval(
-          self._upnpMap.bind(self, opts),
+          self._upnpMap.bind(self, opts, () => {}),
           self._timeout
         )
       }
@@ -374,7 +374,7 @@ class NatAPI {
 
       if (self.autoUpdate) {
         self._pmpIntervals[opts.publicPort + ':' + opts.privatePort + '-' + opts.protocol] = setInterval(
-          self._pmpMap.bind(self, opts),
+          self._pmpMap.bind(self, opts, () => {}),
           self._timeout
         )
       }


### PR DESCRIPTION
When binding functions to use with `setInterval`, these functions expect a callback to be passed so just pass a noop.

Fixes #24